### PR TITLE
Derive package build number from number of git commits since last tag

### DIFF
--- a/conda_pkg/meta.yaml
+++ b/conda_pkg/meta.yaml
@@ -12,9 +12,8 @@ build:
   #
   # - msgpack-python = msgpack-python:main
   #
-  # Would create an entry point called msgpack-python that calls msgpack-python.main()
-  # just always use build number 0 ...
-  number: 0
+  # Use number of commits since last tag as build number -- imperfect but mostly monotonic ...
+  number: "{{GIT_DESCRIBE_NUMBER}}"
 
 requirements:
   build:


### PR DESCRIPTION
Derive the conda PKG_NUMBER from the number of git commits since the last tag.

You should create a tag somewhere in the repo -- suggest tagging the initial repository commit as '1.1'.  The build number will then be the number of commits in the repository since the initial commit -- which is approximately monotonic -- should ensure that libraries which use this package can update to latest build more safely.

When you want to update a project to use updated build of coffee_poisson_solver_ko  -- I believe you can just:

```
conda update coffee_poisson_solver_ko  # update package
conda env export > ...  # keep a shared environment description up to date 
```
