### PR TITLE
CI FIX for failures which occur in 'after_success' section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - conda update -q conda
 script:
   - echo "Building"
-after_success:
   - conda install conda-build anaconda-client conda-verify
   - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then bash -x ./conda_build.sh; else bash -x ./conda_upload.sh; fi
 env:


### PR DESCRIPTION
Failures in after_success apparently do not fail the build. https://github.com/travis-ci/travis-ci/issues/758
Fix by doing all the work within 'script' section